### PR TITLE
[Fix] Transition between v,V,<C-v> is different with original Vim behavior

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2075,7 +2075,7 @@ class CommandClearLine extends BaseCommand {
 
 @RegisterAction
 class CommandExitVisualMode extends BaseCommand {
-  modes = [ModeName.Visual, ModeName.VisualLine];
+  modes = [ModeName.Visual];
   keys = ['v'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
@@ -2087,7 +2087,7 @@ class CommandExitVisualMode extends BaseCommand {
 
 @RegisterAction
 class CommandVisualMode extends BaseCommand {
-  modes = [ModeName.Normal];
+  modes = [ModeName.Normal, ModeName.VisualLine, ModeName.VisualBlock];
   keys = ['v'];
   isCompleteAction = false;
 
@@ -2122,15 +2122,23 @@ class CommandReselectVisual extends BaseCommand {
 
 @RegisterAction
 class CommandVisualBlockMode extends BaseCommand {
-  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualBlock];
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualLine];
   keys = ['<C-v>'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    if (vimState.currentMode === ModeName.VisualBlock) {
-      vimState.currentMode = ModeName.Normal;
-    } else {
-      vimState.currentMode = ModeName.VisualBlock;
-    }
+    vimState.currentMode = ModeName.VisualBlock;
+
+    return vimState;
+  }
+}
+
+@RegisterAction
+class CommandExitVisualBlockMode extends BaseCommand {
+  modes = [ModeName.VisualBlock];
+  keys = ['<C-v>'];
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    vimState.currentMode = ModeName.Normal;
 
     return vimState;
   }
@@ -2138,7 +2146,7 @@ class CommandVisualBlockMode extends BaseCommand {
 
 @RegisterAction
 class CommandVisualLineMode extends BaseCommand {
-  modes = [ModeName.Normal, ModeName.Visual];
+  modes = [ModeName.Normal, ModeName.Visual, ModeName.VisualBlock];
   keys = ['V'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {

--- a/test/mode/modeVisual.test.ts
+++ b/test/mode/modeVisual.test.ts
@@ -874,4 +874,51 @@ suite('Mode Visual', () => {
       end: ['    func() {', '        hi;', '        alw;', '|        hi;', '        alw;', '    }'],
     });
   });
+
+  suite('Transition between visual mode', () => {
+    test('vv will back to normal mode', async () => {
+      await modeHandler.handleMultipleKeyEvents(['v', 'v']);
+      assertEqual(modeHandler.currentMode.name, ModeName.Normal);
+    });
+
+    test('vV will transit to visual line mode', async () => {
+      await modeHandler.handleMultipleKeyEvents(['v', 'V']);
+      assertEqual(modeHandler.currentMode.name, ModeName.VisualLine);
+    });
+
+    test('v<C-v> will transit to visual block mode', async () => {
+      await modeHandler.handleMultipleKeyEvents(['v', '<C-v>']);
+      assertEqual(modeHandler.currentMode.name, ModeName.VisualBlock);
+    });
+
+    test('Vv will transit to visual (char) mode', async () => {
+      await modeHandler.handleMultipleKeyEvents(['V', 'v']);
+      assertEqual(modeHandler.currentMode.name, ModeName.Visual);
+    });
+
+    test('VV will back to normal mode', async () => {
+      await modeHandler.handleMultipleKeyEvents(['V', 'V']);
+      assertEqual(modeHandler.currentMode.name, ModeName.Normal);
+    });
+
+    test('V<C-v> will transit to visual block mode', async () => {
+      await modeHandler.handleMultipleKeyEvents(['V', '<C-v>']);
+      assertEqual(modeHandler.currentMode.name, ModeName.VisualBlock);
+    });
+
+    test('<C-v>v will transit to visual (char) mode', async () => {
+      await modeHandler.handleMultipleKeyEvents(['<C-v>', 'v']);
+      assertEqual(modeHandler.currentMode.name, ModeName.Visual);
+    });
+
+    test('<C-v>V will back to visual line mode', async () => {
+      await modeHandler.handleMultipleKeyEvents(['<C-v>', 'V']);
+      assertEqual(modeHandler.currentMode.name, ModeName.VisualLine);
+    });
+
+    test('<C-v><C-v> will back to normal mode', async () => {
+      await modeHandler.handleMultipleKeyEvents(['<C-v>', '<C-v>']);
+      assertEqual(modeHandler.currentMode.name, ModeName.Normal);
+    });
+  });
 });


### PR DESCRIPTION

<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

# What this PR does / why we need it

I expect the same behavior as original Vim :)

* `vv` -> normal mode
* `VV` -> normal mode
* `<C-v>` -> normal mode

* `vV` -> visual line mode
* `v<C-v>` -> visual block mode
* `Vv` -> visual (char) mode
* `V<C-v>` -> visual block mode
* `<C-v>v` -> visual (char) mode
* `<C-v>V` -> visual line mode

# Which issue(s) this PR fixes

I could not find the issue.
